### PR TITLE
Upgrade Alpine image to Alpine 3.22.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.22.1
 WORKDIR /home/ircd-admin
 COPY motd /etc/ngircd/ngircd.motd
 COPY ngircd.conf /etc/ngircd/ngircd.conf

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ kubectl -n namespace-here apply -f ngircd-deployment.yml
 
 This stack is powered by the following software.
 
-- Operating System: [Alpine Linux 3.18](https://www.alpinelinux.org/)
+- Operating System: [Alpine Linux 3.22.1](https://www.alpinelinux.org/)
 - IRC server: [ngIRCd 26.1](https://github.com/ngircd/ngircd)
 
 ## Configuration


### PR DESCRIPTION
This pull request upgrades Alpine image from obsolete 3.18 to latest iteration. Alpine 3.22.1.